### PR TITLE
Fix: click-me function call

### DIFF
--- a/index.html
+++ b/index.html
@@ -125,7 +125,7 @@
       background: url('play-button.png') no-repeat center center;
       background-size: contain;
     }
-
+    
     @media (min-width: 1024px) {
       .videos-container {
         justify-content: space-between;
@@ -236,7 +236,7 @@
     });
     document.addEventListener("DOMContentLoaded", function () {
       const clickmeImage = document.getElementById("clickme");
-      clickmeImage.addEventListener("click", redirectToLucasMontano);
+      clickmeImage.addEventListener("click", () => redirectToLucasMontano("https://www.youtube.com/@LucasMontano"));
     });
   </script>
   <script src="https://cdn.jsdelivr.net/npm/prismjs@1.25.0/prism.js"></script>


### PR DESCRIPTION
Currently, when someone clicks on the "click me" button/image, due to a bad call in the `redirectToLucasMontano` function, they are redirected to an invalid page with a 404.

![image](https://github.com/lucasmontano/lucasmontano.com/assets/102990211/1dee2577-2eb9-4219-8a3d-f765f1e871c5)

Therefore, following the "if you find an error, this is yours" policy, i created this PR.